### PR TITLE
🔧 add token permissions to release workflow

### DIFF
--- a/.github/workflows/gh_release.yml
+++ b/.github/workflows/gh_release.yml
@@ -8,6 +8,10 @@ on:
     types:
       - closed
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   create_release:
     if: github.event.pull_request.merged && contains( github.event.pull_request.labels.*.name, 'release')


### PR DESCRIPTION
Adds token permissions to the workflow to account for how github now configures token access in new repositories